### PR TITLE
docs: replace hardcoded domain with placeholder examples

### DIFF
--- a/docs/deployment-coolify.md
+++ b/docs/deployment-coolify.md
@@ -4,13 +4,18 @@ This guide deploys Agent Commander on Coolify with Cloudflare DNS.
 
 ## Recommended subdomains
 
-- `agentcommander.co` - public feature dive site
-- `docs.agentcommander.co` - documentation
-- `app.agentcommander.co` - dashboard (keep private if not public)
-- `api.agentcommander.co` - control plane (keep private if not public)
+**Production:**
+- `yourdomain.com` - public feature dive site
+- `docs.yourdomain.com` - documentation
+- `app.yourdomain.com` - dashboard (keep private if not public)
+- `api.yourdomain.com` - control plane (keep private if not public)
 
-If you are not running a public app, only create DNS records for `agentcommander.co`,
-`docs.agentcommander.co`, and `www.agentcommander.co` (redirect to apex).
+**Local development:**
+- `localhost:3000` - dashboard
+- `localhost:8080` - control plane
+
+If you are not running a public app, only create DNS records for `yourdomain.com`,
+`docs.yourdomain.com`, and `www.yourdomain.com` (redirect to apex).
 
 ## Coolify setup
 
@@ -29,7 +34,7 @@ Environment:
 - Optional `DEEPGRAM_API_KEY`
 
 Domain:
-- `api.agentcommander.co` (optional, keep private if you are not exposing the API)
+- `api.yourdomain.com` (optional, keep private if you are not exposing the API)
 
 Health check:
 - `/health`
@@ -38,34 +43,34 @@ Health check:
 Create a service from this repo using `deploy/Dockerfile.dashboard.base`.
 
 Environment:
-- `NEXTAUTH_URL=https://app.agentcommander.co`
+- `NEXTAUTH_URL=https://app.yourdomain.com`
 - `NEXTAUTH_SECRET` - strong secret
 - `CONTROL_PLANE_JWT_SECRET` - must match `JWT_SECRET`
-- `NEXT_PUBLIC_CONTROL_PLANE_URL=https://api.agentcommander.co`
-- `NEXT_PUBLIC_CONTROL_PLANE_WS_URL=wss://api.agentcommander.co/v1/ui/stream`
+- `NEXT_PUBLIC_CONTROL_PLANE_URL=https://api.yourdomain.com`
+- `NEXT_PUBLIC_CONTROL_PLANE_WS_URL=wss://api.yourdomain.com/v1/ui/stream`
 - Optional `ACCESS_SECRET` (access code login)
 - Optional `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`
 - Optional `ADMIN_EMAILS` / `ALLOWED_EMAILS`
 
 Domain:
-- `app.agentcommander.co` (optional, keep private if you are not exposing the dashboard)
+- `app.yourdomain.com` (optional, keep private if you are not exposing the dashboard)
 
 ### 4) GitHub OAuth (optional)
 If using GitHub OAuth, set:
-- Homepage URL: `https://app.agentcommander.co`
-- Callback URL: `https://app.agentcommander.co/api/auth/callback/github`
+- Homepage URL: `https://app.yourdomain.com`
+- Callback URL: `https://app.yourdomain.com/api/auth/callback/github`
 
 ## Public sites
 
-Create two static services from this repo:\n\n1) **Feature site** (apex)\n- Dockerfile: `deploy/Dockerfile.site`\n- Domain: `agentcommander.co`\n\n2) **Docs site**\n- Dockerfile: `deploy/Dockerfile.docs`\n- Domain: `docs.agentcommander.co`
+Create two static services from this repo:\n\n1) **Feature site** (apex)\n- Dockerfile: `deploy/Dockerfile.site`\n- Domain: `yourdomain.com`\n\n2) **Docs site**\n- Dockerfile: `deploy/Dockerfile.docs`\n- Domain: `docs.yourdomain.com`
 
 ## Cloudflare DNS
 
 Create A records pointing to your Coolify server IP:
 
-- `agentcommander.co` -> `<server-ip>`
-- `docs.agentcommander.co` -> `<server-ip>`
-- `www.agentcommander.co` -> `<server-ip>` (redirect to apex)
+- `yourdomain.com` -> `<server-ip>`
+- `docs.yourdomain.com` -> `<server-ip>`
+- `www.yourdomain.com` -> `<server-ip>` (redirect to apex)
 
 Recommended Cloudflare settings:
 - SSL/TLS mode: Full (strict)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,11 @@ Agent Commander ships as two services (dashboard + control plane) plus Postgres.
 The host agent (agentd) runs separately on each machine you want to manage.
 
 See [Coolify Deployment](deployment-coolify.md) for a production setup with
-`app.agentcommander.co` and `api.agentcommander.co` subdomains.
+`app.yourdomain.com` and `api.yourdomain.com` subdomains.
+
+**Example URLs:**
+- Production: `app.yourdomain.com`, `api.yourdomain.com`
+- Local: `localhost:3000` (dashboard), `localhost:8080` (control plane)
 
 ## Docker Compose (quick start)
 


### PR DESCRIPTION
## Summary
- Replace `agentcommander.co` references with `yourdomain.com` placeholder in deployment docs
- Add local development URL examples (`localhost:3000`, `localhost:8080`)

## Test plan
- [ ] Verify docs render correctly
- [ ] Check no broken links introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guides with customizable domain configuration examples for production and local development environments
  * Added local development setup instructions for dashboard and control plane
  * Clarified DNS records and environment configuration guidance for self-hosted deployments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->