### PR TITLE
Fix OpenCode utilization percent

### DIFF
--- a/apps/dashboard/src/components/analytics/ProviderUtilization.tsx
+++ b/apps/dashboard/src/components/analytics/ProviderUtilization.tsx
@@ -373,8 +373,16 @@ export function ProviderUtilization({ usage }: ProviderUtilizationProps) {
     }
 
     let utilization: number | null = null;
+    let usedFromRemaining: number | null = null;
     if (effectiveTotal != null && effectiveTotal > 0) {
-      if (usedRequests != null) {
+      if (overrideLimit != null) {
+        if (remainingRequests != null) {
+          usedFromRemaining = Math.max(0, effectiveTotal - remainingRequests);
+          utilization = (usedFromRemaining / effectiveTotal) * 100;
+        } else if (usedRequests != null) {
+          utilization = (usedRequests / effectiveTotal) * 100;
+        }
+      } else if (usedRequests != null) {
         utilization = (usedRequests / effectiveTotal) * 100;
       } else if (remainingRequests != null) {
         utilization = ((effectiveTotal - remainingRequests) / effectiveTotal) * 100;
@@ -392,7 +400,7 @@ export function ProviderUtilization({ usage }: ProviderUtilizationProps) {
     const remainingLabel =
       remainingRequests != null
         ? overrideLimit != null
-          ? `${Math.max(0, Math.round(remainingRequests)).toLocaleString()} / ${Math.round(overrideLimit).toLocaleString()} requests remaining`
+          ? `${Math.round((usedFromRemaining ?? Math.max(0, overrideLimit - remainingRequests))).toLocaleString()} / ${Math.round(overrideLimit).toLocaleString()} used • ${Math.max(0, Math.round(remainingRequests)).toLocaleString()} remaining`
           : `${Math.max(0, Math.round(remainingRequests)).toLocaleString()} requests remaining`
         : null;
 


### PR DESCRIPTION
- compute utilization from override limit + remaining requests\n- show used/limit and remaining counts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved utilization calculation for provider analytics when override limits are set, ensuring accurate tracking of used resources.
  * Enhanced remaining requests display to show a clearer breakdown of used, total limit, and remaining values in a single, unified format for better visibility of quota status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->