### PR TITLE
Throttle sessions.changed and cooldown usage updates

### DIFF
--- a/apps/dashboard/src/components/SessionList.tsx
+++ b/apps/dashboard/src/components/SessionList.tsx
@@ -372,6 +372,7 @@ export function SessionList({
   useSessionUsageStream({
     sessionIds: visibleSessionIds,
     enabled: !disableRealtime,
+    cooldownMs: 5000,
   });
 
   // Track previous values to detect changes for perf logging


### PR DESCRIPTION
## Summary
- throttle sessions.changed publishes to skip activity-only noise
- apply per-session cooldown on usage stream updates
- tune SessionList usage stream cooldown

## Testing
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable cooldown mechanism to session usage streaming (default 5 seconds).

* **Performance Improvements**
  * Implemented fingerprint-based deduplication for session updates to reduce unnecessary notifications.
  * Session activity changes are now throttled with a 30-second window to minimize update frequency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->