### PR TITLE
Add heap/payload diagnostics for /sessions

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/sessions/SessionsPageClient.tsx
+++ b/apps/dashboard/src/app/(dashboard)/sessions/SessionsPageClient.tsx
@@ -13,7 +13,12 @@ import { ShortcutsHelp, useShortcutsHelp } from '@/components/shortcuts/Shortcut
 import { ImportOrphanPanesModal, useImportModal } from '@/components/import/ImportOrphanPanesModal';
 import { SessionGenerator } from '@/components/session-generator';
 import { getHosts, assignSessionGroup } from '@/lib/api';
-import { setSessionsPerfEnabled, startSessionsPerfLogging, stopSessionsPerfLogging } from '@/lib/sessionsPerf';
+import {
+  setSessionsPerfEnabled,
+  setSessionsPerfSampleRate,
+  startSessionsPerfLogging,
+  stopSessionsPerfLogging,
+} from '@/lib/sessionsPerf';
 import { useSessionStore } from '@/stores/session';
 
 // Status filter shortcuts - apply when search input is not focused
@@ -262,6 +267,7 @@ export default function SessionsPageClient() {
   useEffect(() => {
     setSessionsPerfEnabled(perfEnabled);
     if (perfEnabled) {
+      setSessionsPerfSampleRate(1);
       startSessionsPerfLogging();
       return () => stopSessionsPerfLogging();
     }

--- a/apps/dashboard/src/components/SessionList.tsx
+++ b/apps/dashboard/src/components/SessionList.tsx
@@ -276,6 +276,22 @@ export function SessionList({
         perfCounters.current.messages += 1;
         perfCounters.current.updated += updates.length;
         perfCounters.current.deleted += deleted?.length || 0;
+        let snapshotBytes = 0;
+        let snapshotCount = 0;
+        for (const session of updates) {
+          const captureText = (session as SessionWithSnapshot).latest_snapshot?.capture_text;
+          if (captureText) {
+            snapshotCount += 1;
+            snapshotBytes += captureText.length;
+          }
+        }
+        if (snapshotCount > 0) {
+          console.log('[perf] sessions.payload', {
+            updated: updates.length,
+            snapshotCount,
+            snapshotBytes,
+          });
+        }
       }
 
       queueSessionUpdates(updates, deleted);


### PR DESCRIPTION
## Summary
- log JS heap usage when perf=1
- log snapshot payload sizes in sessions.changed
- force callsite sampling to 100% for perf mode

## Testing
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable performance sampling rates now provide fine-grained control over monitoring coverage and telemetry collection efficiency to match your specific operational needs.
  * Expanded performance metrics now track memory consumption patterns and deliver detailed session snapshot statistics for significantly enhanced observability and insights.

* **Improvements**
  * Strengthened server-side rendering stability for performance instrumentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->