### PR TITLE
Log sessions payload size and callers

### DIFF
--- a/apps/dashboard/src/components/SessionList.tsx
+++ b/apps/dashboard/src/components/SessionList.tsx
@@ -276,6 +276,12 @@ export function SessionList({
         perfCounters.current.messages += 1;
         perfCounters.current.updated += updates.length;
         perfCounters.current.deleted += deleted?.length || 0;
+        let payloadBytes = 0;
+        try {
+          payloadBytes = JSON.stringify(updates).length;
+        } catch {
+          payloadBytes = 0;
+        }
         let snapshotBytes = 0;
         let snapshotCount = 0;
         for (const session of updates) {
@@ -285,13 +291,12 @@ export function SessionList({
             snapshotBytes += captureText.length;
           }
         }
-        if (snapshotCount > 0) {
-          console.log('[perf] sessions.payload', {
-            updated: updates.length,
-            snapshotCount,
-            snapshotBytes,
-          });
-        }
+        console.log('[perf] sessions.payload', {
+          updated: updates.length,
+          payloadBytes,
+          snapshotCount,
+          snapshotBytes,
+        });
       }
 
       queueSessionUpdates(updates, deleted);

--- a/apps/dashboard/src/lib/sessionsPerf.ts
+++ b/apps/dashboard/src/lib/sessionsPerf.ts
@@ -126,6 +126,7 @@ export function startSessionsPerfLogging(intervalMs: number = 2000): void {
         .slice(0, 8)
         .map(([key, count]) => ({ count, key }));
       console.log('[perf] sessions.callers (sampled)', top);
+      console.log('[perf] sessions.callers.json', JSON.stringify(top));
     }
 
     resetCounters();


### PR DESCRIPTION
## Summary
- log sessions.changed payload size on /sessions perf mode
- always emit payload stats and JSON callsite list

## Testing
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved performance monitoring by tracking expanded metrics including payload size during session updates
  * Enhanced diagnostic logging with detailed callsite caller information for better visibility into session operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->