### PR TITLE
Persist usage warnings and tmux spawn naming

### DIFF
--- a/apps/dashboard/src/components/session-generator/SessionGenerator.tsx
+++ b/apps/dashboard/src/components/session-generator/SessionGenerator.tsx
@@ -140,6 +140,10 @@ export function SessionGenerator({
           .map((f) => f.trim())
           .filter(Boolean);
 
+        const windowName = session.title?.trim() || session.provider;
+        const targetSession = selectedRepo.name?.trim()
+          || selectedRepo.path.split('/').filter(Boolean).pop()
+          || undefined;
         const result = await spawnSession({
           host_id: selectedHostId,
           provider: session.provider,
@@ -147,6 +151,10 @@ export function SessionGenerator({
           title: session.title || undefined,
           flags: flagsArray.length > 0 ? flagsArray : undefined,
           group_id: groupId || undefined,
+          tmux: {
+            target_session: targetSession,
+            window_name: windowName,
+          },
         });
 
         sessionIds.push(result.session.id);

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -747,6 +747,10 @@ export interface SpawnSessionRequest {
   title?: string;
   flags?: string[];
   group_id?: string;
+  tmux?: {
+    target_session?: string;
+    window_name?: string;
+  };
 }
 
 export async function spawnSession(

--- a/packages/ac-schema/src/command.ts
+++ b/packages/ac-schema/src/command.ts
@@ -34,6 +34,12 @@ export const SpawnSessionInteractivePayloadSchema = z.object({
   title: z.string().optional(),
   flags: z.array(z.string()).optional(),
   group_id: z.string().uuid().optional(),
+  tmux: z
+    .object({
+      target_session: z.string().optional(),
+      window_name: z.string().optional(),
+    })
+    .optional(),
 });
 
 // Spawn session command payload (worktree + tmux window)

--- a/services/control-plane/src/routes/sessions.ts
+++ b/services/control-plane/src/routes/sessions.ts
@@ -750,6 +750,12 @@ export function registerSessionRoutes(app: FastifyInstance): void {
     title: z.string().optional(),
     flags: z.array(z.string()).optional(),
     group_id: z.string().uuid().optional(),
+    tmux: z
+      .object({
+        target_session: z.string().optional(),
+        window_name: z.string().optional(),
+      })
+      .optional(),
   });
 
   app.post<{ Body: unknown }>('/v1/sessions/spawn', async (request, reply) => {
@@ -762,7 +768,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
       return reply.status(400).send({ error: 'Invalid request body', details: bodyResult.error });
     }
 
-    const { host_id, provider, working_directory, title, flags, group_id } = bodyResult.data;
+    const { host_id, provider, working_directory, title, flags, group_id, tmux } = bodyResult.data;
 
     // Verify host exists
     const host = await db.getHostById(host_id);
@@ -829,6 +835,7 @@ export function registerSessionRoutes(app: FastifyInstance): void {
             title,
             flags,
             group_id,
+            tmux,
           },
         },
       },


### PR DESCRIPTION
- persist provider usage threshold warnings across reloads (expires at reset)
- allow dashboard spawn to pass tmux target/session window names
- agent respects optional tmux target/window on interactive spawn