### PR TITLE
Preserve dev folders on sync + tmux target in spawn dialog

### DIFF
--- a/apps/dashboard/src/components/SpawnSessionDialog.tsx
+++ b/apps/dashboard/src/components/SpawnSessionDialog.tsx
@@ -114,6 +114,12 @@ export function SpawnSessionDialog({
       .split(/\s+/)
       .map((f) => f.trim())
       .filter(Boolean);
+    const trimmedWorkingDir = workingDirectory.trim().replace(/\/+$/, '');
+    const targetSession = trimmedWorkingDir
+      .split('/')
+      .filter(Boolean)
+      .pop();
+    const windowName = title.trim() || provider;
 
     spawnMutation.mutate({
       host_id: hostId,
@@ -122,6 +128,10 @@ export function SpawnSessionDialog({
       title: title.trim() || undefined,
       flags: flagsArray.length > 0 ? flagsArray : undefined,
       group_id: groupId || undefined,
+      tmux: {
+        target_session: targetSession || undefined,
+        window_name: windowName,
+      },
     });
   };
 

--- a/apps/dashboard/src/components/settings/SettingsSync.tsx
+++ b/apps/dashboard/src/components/settings/SettingsSync.tsx
@@ -178,7 +178,22 @@ export function SettingsSync() {
 
       if (remote.settings) {
         const merged = mergeSettings(remote.settings);
-        const mergedHash = JSON.stringify(merged);
+        const local = useSettingsStore.getState();
+        const mergedWithLocal: NormalizedUserSettings = {
+          ...merged,
+          data: {
+            ...merged.data,
+            devFolders:
+              merged.data.devFolders.length > 0
+                ? merged.data.devFolders
+                : local.devFolders,
+            repoLastUsed:
+              Object.keys(merged.data.repoLastUsed).length > 0
+                ? merged.data.repoLastUsed
+                : local.repoLastUsed,
+          },
+        };
+        const mergedHash = JSON.stringify(mergedWithLocal);
         const currentHash = JSON.stringify(buildPayload());
 
         if (mergedHash !== currentHash) {
@@ -194,10 +209,10 @@ export function SettingsSync() {
             notificationsEnabled: merged.data.notificationsEnabled,
             audioEnabled: merged.data.audioEnabled,
             alertSettings: merged.data.alertSettings,
-            devFolders: merged.data.devFolders,
+            devFolders: mergedWithLocal.data.devFolders,
             repoSortBy: merged.data.repoSortBy,
             showHiddenFolders: merged.data.showHiddenFolders,
-            repoLastUsed: merged.data.repoLastUsed,
+            repoLastUsed: mergedWithLocal.data.repoLastUsed,
             defaultProvider: coerceProvider(merged.data.defaultProvider),
             sessionNamingPattern: merged.data.sessionNamingPattern,
             autoCreateGroup: merged.data.autoCreateGroup,


### PR DESCRIPTION
- keep local dev folders/repo history if remote settings are empty
- pass tmux target session/window name in SpawnSessionDialog based on working directory/title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tmux sessions now spawn with automatically derived session and window names based on working directory and title.

* **Bug Fixes**
  * Settings synchronization now properly preserves local values when remote settings are incomplete or missing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->