### PR TITLE
Suppress CodeQL weak-crypto false positive

### DIFF
--- a/services/control-plane/src/auth/verify.ts
+++ b/services/control-plane/src/auth/verify.ts
@@ -37,6 +37,8 @@ function uuidv5(name: string, namespace: string): string {
   const toHash = new Uint8Array(nsBytes.length + nameBytes.length);
   toHash.set(nsBytes);
   toHash.set(nameBytes, nsBytes.length);
+  // uuidv5 requires SHA-1; this is for deterministic IDs, not security.
+  // lgtm[js/weak-cryptographic-algorithm]
   const hash = createHash('sha1').update(toHash).digest();
   const bytes = Uint8Array.from(hash.slice(0, 16));
   const b6 = bytes[6] ?? 0;


### PR DESCRIPTION
## Summary\n- Suppress CodeQL weak-crypto warning for deterministic UUID v5 hashing (non-security use).\n\n## Testing\n- Not run (comment-only change).\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code documentation with clarifying comments regarding authentication verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->