### PR TITLE
Fix orchestrator attention + mobile terminal UX

### DIFF
--- a/apps/dashboard/src/app/(dashboard)/layout.tsx
+++ b/apps/dashboard/src/app/(dashboard)/layout.tsx
@@ -4,6 +4,7 @@ import { LayoutShell } from '@/components/layout';
 import { MobileHeader } from '@/components/layout/MobileHeader';
 import { SettingsButton } from '@/components/settings';
 import { AuthControls } from '@/components/auth/AuthControls';
+import { OrchestratorButton, OrchestratorModal } from '@/components/orchestrator';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -25,6 +26,7 @@ export default function DashboardLayout({
             </a>
           </div>
           <div className="flex items-center gap-2">
+            <OrchestratorButton />
             <ThemeToggle />
             <SettingsButton />
             <AuthControls />
@@ -34,6 +36,9 @@ export default function DashboardLayout({
 
       {/* Main content with sidebar */}
       <LayoutShell>{children}</LayoutShell>
+
+      {/* Global overlay */}
+      <OrchestratorModal />
     </div>
   );
 }

--- a/apps/dashboard/src/app/(dashboard)/orchestrator/OrchestratorPageClient.tsx
+++ b/apps/dashboard/src/app/(dashboard)/orchestrator/OrchestratorPageClient.tsx
@@ -13,7 +13,7 @@ import { OrchestratorItem } from '@/components/orchestrator/OrchestratorItem';
 import { useOrchestratorSummaries } from '@/hooks/useOrchestratorSummaries';
 
 export default function OrchestratorPageClient() {
-  const attentionStatusFilter = 'WAITING_FOR_INPUT,WAITING_FOR_APPROVAL,ERROR';
+  const workflowStatusFilter = 'RUNNING,STARTING,WAITING_FOR_INPUT,WAITING_FOR_APPROVAL,ERROR,IDLE';
   const [idleExpanded, setIdleExpanded] = useState(false);
   const {
     ingestSessions,
@@ -23,6 +23,7 @@ export default function OrchestratorPageClient() {
     pruneApprovals,
     dismissItem,
     getActiveItems,
+    getWaitingItems,
     getIdledItems,
   } = useOrchestratorStore();
   const { setSessionIdle } = useSessionIdle();
@@ -50,13 +51,14 @@ export default function OrchestratorPageClient() {
   );
 
   const activeItems = getActiveItems();
+  const waitingItems = getWaitingItems();
   const idledItems = getIdledItems();
 
   // Fetch initial sessions
   const { refetch: refetchSessions } = useQuery({
     queryKey: ['orchestrator', 'sessions'],
     queryFn: async () => {
-      const data = await getSessions({ include_archived: false, status: attentionStatusFilter });
+      const data = await getSessions({ include_archived: false, status: workflowStatusFilter });
       // Filter to sessions that might need attention
       ingestSessions(data.sessions as any, { fullSync: true });
       return data;
@@ -134,7 +136,7 @@ export default function OrchestratorPageClient() {
 
   useWebSocket(
     [
-      { type: 'sessions', filter: { status: attentionStatusFilter } },
+      { type: 'sessions', filter: { status: workflowStatusFilter } },
       { type: 'snapshots' },
       { type: 'approvals', filter: { status: 'pending' } },
     ],
@@ -172,7 +174,7 @@ export default function OrchestratorPageClient() {
       )}
 
       {/* Empty state */}
-      {activeItems.length === 0 && idledItems.length === 0 && (
+      {activeItems.length === 0 && waitingItems.length === 0 && idledItems.length === 0 && (
         <div className="text-center py-16 text-muted-foreground">
           <Bell className="h-16 w-16 mx-auto mb-4 opacity-30" />
           <p className="text-lg">No sessions need your attention</p>
@@ -204,8 +206,31 @@ export default function OrchestratorPageClient() {
         </section>
       )}
 
+      {/* Waiting items */}
+      {waitingItems.length > 0 && (
+        <section className="mb-8">
+          <h2 className="text-lg font-semibold mb-4 text-muted-foreground">
+            Waiting ({waitingItems.length})
+          </h2>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {waitingItems.map((item) => (
+              <OrchestratorItem
+                key={item.id}
+                item={item}
+                onDismiss={dismissItem}
+                onIdle={handleIdle}
+                onUnidle={handleUnidle}
+                onResponseSent={handleRefresh}
+                summariesEnabled={summariesEnabled}
+                mode="waiting"
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
       {/* All items idled message */}
-      {activeItems.length === 0 && idledItems.length > 0 && (
+      {activeItems.length === 0 && waitingItems.length === 0 && idledItems.length > 0 && (
         <div className="text-center py-8 text-muted-foreground mb-4">
           <p className="text-sm">All items are idled</p>
         </div>

--- a/apps/dashboard/src/app/(dashboard)/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/page.tsx
@@ -20,11 +20,7 @@ export default function Dashboard() {
   const queryClient = useQueryClient();
   const [showSpawnDialog, setShowSpawnDialog] = useState(false);
   const { sessions, setSessions, updateSessions } = useSessionStore();
-  const {
-    ingestSessions: ingestOrchestratorSessions,
-    ingestSnapshot,
-    getWaitingItems,
-  } = useOrchestratorStore();
+  const { getWaitingItems } = useOrchestratorStore();
   const workflowStatuses = 'RUNNING,STARTING,WAITING_FOR_INPUT,WAITING_FOR_APPROVAL,ERROR,IDLE';
 
   // Fetch initial data
@@ -43,33 +39,20 @@ export default function Dashboard() {
   useEffect(() => {
     if (sessionData?.sessions) {
       setSessions(sessionData.sessions);
-      ingestOrchestratorSessions(sessionData.sessions as any, { fullSync: true });
     }
-  }, [sessionData, setSessions, ingestOrchestratorSessions]);
+  }, [sessionData, setSessions]);
 
   // WebSocket for real-time updates
   const handleWebSocketMessage = useCallback((message: ServerToUIMessage) => {
     if (message.type === 'sessions.changed') {
       const payload = message.payload as { sessions: Session[]; deleted?: string[] };
       updateSessions(payload.sessions, payload.deleted);
-      if (payload.sessions.length > 0) {
-        ingestOrchestratorSessions(payload.sessions as any);
-      }
     }
-    if (message.type === 'snapshots.updated') {
-      const payload = message.payload as {
-        session_id: string;
-        capture_text: string;
-        capture_hash?: string;
-      };
-      ingestSnapshot(payload.session_id, payload.capture_text, payload.capture_hash);
-    }
-  }, [updateSessions, ingestOrchestratorSessions, ingestSnapshot]);
+  }, [updateSessions]);
 
   useWebSocket(
     [
       { type: 'sessions', filter: { include_archived: false, status: workflowStatuses } },
-      { type: 'snapshots' },
     ],
     handleWebSocketMessage
   );

--- a/apps/dashboard/src/app/(dashboard)/sessions/[id]/page.tsx
+++ b/apps/dashboard/src/app/(dashboard)/sessions/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState, useRef, useEffect, useCallback } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Pencil, Check, X, Plug, Send, ChevronLeft, Moon, Sun, Power } from 'lucide-react';
+import { Pencil, Check, X, Plug, Send, ChevronLeft, Moon, Sun, Power, Maximize2, Minimize2 } from 'lucide-react';
 import Link from 'next/link';
 import { assignSessionGroup, getGroups, getHosts, getSession, updateSession } from '@/lib/api';
 import { StatusBadge } from '@/components/StatusBadge';
@@ -50,6 +50,7 @@ export default function SessionDetailPage() {
 
   // Console/Terminal view toggle - initialized from URL param
   const [viewMode, setViewMode] = useState<'console' | 'terminal'>(initialView);
+  const [maximized, setMaximized] = useState(false);
   const { addRecentSession } = useUIStore();
   const recentKeyRef = useRef<string | null>(null);
   const isMobile = useIsMobile();
@@ -228,6 +229,28 @@ export default function SessionDetailPage() {
     window.addEventListener('keydown', handleGlobalKeyDown);
     return () => window.removeEventListener('keydown', handleGlobalKeyDown);
   }, [data?.session, sessionId, mcpManager]);
+
+  // Escape key exits maximized terminal
+  useEffect(() => {
+    if (!maximized) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      // Don't steal Escape from text inputs / dialogs.
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      setMaximized(false);
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [maximized]);
 
   useWebSocket(
     [
@@ -476,7 +499,9 @@ export default function SessionDetailPage() {
         {/* Console/Terminal - full width */}
         <Card className={cn(
           'flex flex-col',
-          isMobile ? 'h-[66vh] min-h-[360px]' : 'h-[66vh]'
+          maximized
+            ? 'fixed inset-0 z-[60] rounded-none border-0 h-screen'
+            : isMobile ? 'h-[66vh] min-h-[360px]' : 'h-[66vh]'
         )}>
           <CardHeader className="py-3">
             <div className="flex items-center justify-between">
@@ -501,6 +526,15 @@ export default function SessionDetailPage() {
                   title={!session.tmux_pane_id ? 'No tmux pane available' : 'Interactive terminal'}
                 >
                   Terminal
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setMaximized(!maximized)}
+                  className="h-7 px-2"
+                  title={maximized ? 'Exit fullscreen (Esc)' : 'Fullscreen'}
+                >
+                  {maximized ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
                 </Button>
               </div>
             </div>

--- a/apps/dashboard/src/app/globals.css
+++ b/apps/dashboard/src/app/globals.css
@@ -91,7 +91,6 @@
 .xterm .xterm-viewport {
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
-  touch-action: pan-y;
 }
 
 /* Mobile text selection support */
@@ -110,9 +109,9 @@
     -webkit-touch-callout: default !important;
   }
 
-  /* Ensure xterm viewport still allows vertical scrolling */
+  /* JS handles touch scrolling for xterm — disable browser gestures */
   .xterm .xterm-viewport {
-    touch-action: pan-y;
+    touch-action: none;
   }
 
   /* Selection styling for better visibility */

--- a/apps/dashboard/src/components/TerminalView.tsx
+++ b/apps/dashboard/src/components/TerminalView.tsx
@@ -32,11 +32,22 @@ export function TerminalView({ sessionId, paneId, className }: TerminalViewProps
   const readOnlyRef = useRef(false);
   const intentionalCloseRef = useRef(false);
   const suppressCloseErrorRef = useRef(false);
-  const touchScrollRef = useRef<{ lastY: number; lastX: number; remainder: number; active: boolean }>({
+  const touchScrollRef = useRef<{
+    lastY: number;
+    lastX: number;
+    remainder: number;
+    active: boolean;
+    velocity: number;
+    lastTime: number;
+    momentumRaf: number | null;
+  }>({
     lastY: 0,
     lastX: 0,
     remainder: 0,
     active: false,
+    velocity: 0,
+    lastTime: 0,
+    momentumRaf: null,
   });
 
   const [status, setStatus] = useState<ConnectionStatus>('disconnected');
@@ -459,48 +470,107 @@ export function TerminalView({ sessionId, paneId, className }: TerminalViewProps
     if (!isMobile) return;
     const container = termRef.current;
     if (!container) return;
+    const touchState = touchScrollRef.current;
 
     const handleTouchStart = (event: TouchEvent) => {
       if (!terminalRef.current) return;
+      if (event.touches.length !== 1) return;
       const touch = event.touches[0];
       if (!touch) return;
-      touchScrollRef.current.active = true;
-      touchScrollRef.current.lastY = touch.clientY;
-      touchScrollRef.current.lastX = touch.clientX;
-      touchScrollRef.current.remainder = 0;
+      // Cancel any running momentum
+      if (touchState.momentumRaf !== null) {
+        cancelAnimationFrame(touchState.momentumRaf);
+        touchState.momentumRaf = null;
+      }
+      touchState.active = true;
+      touchState.lastY = touch.clientY;
+      touchState.lastX = touch.clientX;
+      touchState.remainder = 0;
+      touchState.velocity = 0;
+      touchState.lastTime = performance.now();
     };
 
     const handleTouchMove = (event: TouchEvent) => {
-      if (!touchScrollRef.current.active) return;
+      if (!touchState.active) return;
       if (hasSelection) return;
+      if (event.touches.length !== 1) return;
       const touch = event.touches[0];
       if (!touch) return;
-      const deltaY = touch.clientY - touchScrollRef.current.lastY;
-      const deltaX = touch.clientX - touchScrollRef.current.lastX;
+      const deltaY = touch.clientY - touchState.lastY;
+      const deltaX = touch.clientX - touchState.lastX;
+      // Only handle vertical gestures
       if (Math.abs(deltaY) < Math.abs(deltaX)) {
-        touchScrollRef.current.lastY = touch.clientY;
-        touchScrollRef.current.lastX = touch.clientX;
+        touchState.lastY = touch.clientY;
+        touchState.lastX = touch.clientX;
         return;
       }
+      // Always preventDefault on vertical gesture to stop browser competing
+      event.preventDefault();
       const terminal = terminalRef.current;
       if (!terminal) return;
       const rows = terminal.rows || 0;
       const height = container.clientHeight || 0;
       const lineHeight = rows > 0 && height > 0 ? height / rows : 16;
-      const totalDelta = deltaY + touchScrollRef.current.remainder;
+      const totalDelta = deltaY + touchState.remainder;
       const lines = Math.trunc(totalDelta / lineHeight);
-      touchScrollRef.current.remainder = totalDelta - lines * lineHeight;
+      touchState.remainder = totalDelta - lines * lineHeight;
       if (lines !== 0) {
         terminal.scrollLines(-lines);
-        event.preventDefault();
       }
-      touchScrollRef.current.lastY = touch.clientY;
-      touchScrollRef.current.lastX = touch.clientX;
+      // Track velocity for momentum (px/ms)
+      const now = performance.now();
+      const dt = now - touchState.lastTime;
+      if (dt > 0) {
+        touchState.velocity = deltaY / dt;
+      }
+      touchState.lastTime = now;
+      touchState.lastY = touch.clientY;
+      touchState.lastX = touch.clientX;
     };
 
     const handleTouchEnd = () => {
-      touchScrollRef.current.active = false;
-      touchScrollRef.current.remainder = 0;
+      touchState.active = false;
+      const velocity = touchState.velocity;
+      const VELOCITY_THRESHOLD = 0.5; // px/ms
+      const FRICTION = 0.95;
+      const MIN_VELOCITY = 0.1; // px/ms
+
+      if (Math.abs(velocity) < VELOCITY_THRESHOLD) {
+        touchState.remainder = 0;
+        return;
+      }
+
+      // Start momentum scrolling
+      let currentVelocity = velocity;
+      let accum = 0;
+      let lastFrame = performance.now();
+
+      const tick = () => {
+        const terminal = terminalRef.current;
+        if (!terminal) {
+          touchState.momentumRaf = null;
+          return;
+        }
+        const now = performance.now();
+        const dt = now - lastFrame;
+        lastFrame = now;
+        currentVelocity *= FRICTION;
+        if (Math.abs(currentVelocity) < MIN_VELOCITY) {
+          touchState.momentumRaf = null;
+          return;
+        }
+        accum += currentVelocity * dt;
+        const rows = terminal.rows || 0;
+        const height = container.clientHeight || 0;
+        const lineHeight = rows > 0 && height > 0 ? height / rows : 16;
+        const lines = Math.trunc(accum / lineHeight);
+        if (lines !== 0) {
+          terminal.scrollLines(-lines);
+          accum -= lines * lineHeight;
+        }
+        touchState.momentumRaf = requestAnimationFrame(tick);
+      };
+      touchState.momentumRaf = requestAnimationFrame(tick);
     };
 
     container.addEventListener('touchstart', handleTouchStart, { passive: true });
@@ -513,6 +583,10 @@ export function TerminalView({ sessionId, paneId, className }: TerminalViewProps
       container.removeEventListener('touchmove', handleTouchMove);
       container.removeEventListener('touchend', handleTouchEnd);
       container.removeEventListener('touchcancel', handleTouchEnd);
+      if (touchState.momentumRaf !== null) {
+        cancelAnimationFrame(touchState.momentumRaf);
+        touchState.momentumRaf = null;
+      }
     };
   }, [isMobile, hasSelection]);
 
@@ -527,6 +601,7 @@ export function TerminalView({ sessionId, paneId, className }: TerminalViewProps
 
   // Cleanup on unmount
   useEffect(() => {
+    const touchState = touchScrollRef.current;
     if (typeof window !== 'undefined') {
       if (window.visualViewport) {
         window.visualViewport.addEventListener('resize', handleViewportResize);
@@ -541,6 +616,10 @@ export function TerminalView({ sessionId, paneId, className }: TerminalViewProps
       }
       if (resizeObserverRef.current) {
         resizeObserverRef.current.disconnect();
+      }
+      if (touchState.momentumRaf !== null) {
+        cancelAnimationFrame(touchState.momentumRaf);
+        touchState.momentumRaf = null;
       }
       // Clean up viewport listeners
       if (typeof window !== 'undefined') {
@@ -658,7 +737,8 @@ export function TerminalView({ sessionId, paneId, className }: TerminalViewProps
           window.setTimeout(() => terminalRef.current?.focus(), 0);
         }}
         className={cn(
-          'flex-1 min-h-0 bg-[#0a0a0a] p-1 overflow-hidden focus:outline-none cursor-text relative touch-pan-y',
+          'flex-1 min-h-0 bg-[#0a0a0a] p-1 overflow-hidden focus:outline-none cursor-text relative',
+          isMobile && 'touch-none',
           status === 'connected' && 'border-l-2 border-emerald-500 shadow-[inset_2px_0_0_rgba(16,185,129,0.35)]'
         )}
         aria-label="Interactive terminal"

--- a/apps/dashboard/src/components/orchestrator/OrchestratorButton.tsx
+++ b/apps/dashboard/src/components/orchestrator/OrchestratorButton.tsx
@@ -15,18 +15,14 @@ import { useOrchestratorStore } from '@/stores/orchestrator';
  */
 export function OrchestratorButton() {
   const attentionStatusFilter = 'WAITING_FOR_INPUT,WAITING_FOR_APPROVAL,ERROR';
-  const {
-    toggle,
-    isOpen,
-    getItemCount,
-    ingestSessions,
-    ingestApproval,
-    removeApprovalItem,
-    pruneApprovals,
-  } =
-    useOrchestratorStore();
-
-  const itemCount = getItemCount();
+  const toggle = useOrchestratorStore((s) => s.toggle);
+  const isOpen = useOrchestratorStore((s) => s.isOpen);
+  const itemCount = useOrchestratorStore((s) => s.getItemCount());
+  const ingestSessions = useOrchestratorStore((s) => s.ingestSessions);
+  const ingestSnapshot = useOrchestratorStore((s) => s.ingestSnapshot);
+  const ingestApproval = useOrchestratorStore((s) => s.ingestApproval);
+  const removeApprovalItem = useOrchestratorStore((s) => s.removeApprovalItem);
+  const pruneApprovals = useOrchestratorStore((s) => s.pruneApprovals);
 
   // Seed initial counts (sessions + approvals)
   useEffect(() => {
@@ -72,6 +68,16 @@ export function OrchestratorButton() {
           break;
         }
 
+        case 'snapshots.updated': {
+          const payload = message.payload as {
+            session_id: string;
+            capture_text: string;
+            capture_hash?: string;
+          };
+          ingestSnapshot(payload.session_id, payload.capture_text, payload.capture_hash);
+          break;
+        }
+
         case 'approvals.created': {
           const payload = message.payload as {
             approval_id: string;
@@ -99,13 +105,16 @@ export function OrchestratorButton() {
         }
       }
     },
-    [ingestSessions, ingestApproval, removeApprovalItem]
+    [ingestSessions, ingestSnapshot, ingestApproval, removeApprovalItem]
   );
 
-  // Always subscribe to sessions and approvals for badge count
+  // Always subscribe to sessions, snapshots, and approvals for badge count
   useWebSocket(
     [
-      { type: 'sessions', filter: { status: attentionStatusFilter } },
+      // Subscribe broadly so we can clear items when sessions leave attention statuses
+      // (server-side filtering only emits sessions that currently match the filter).
+      { type: 'sessions', filter: { include_archived: true } },
+      { type: 'snapshots' },
       { type: 'approvals', filter: { status: 'pending' } },
     ],
     handleWebSocketMessage

--- a/apps/dashboard/src/components/orchestrator/OrchestratorModal.tsx
+++ b/apps/dashboard/src/components/orchestrator/OrchestratorModal.tsx
@@ -18,11 +18,16 @@ interface OrchestratorModalProps {
 }
 
 export function OrchestratorModal({ className }: OrchestratorModalProps) {
-  const attentionStatusFilter = 'WAITING_FOR_INPUT,WAITING_FOR_APPROVAL,ERROR';
+  const isOpen = useOrchestratorStore((s) => s.isOpen);
+  if (!isOpen) return null;
+  return <OrchestratorModalContent className={className} />;
+}
+
+function OrchestratorModalContent({ className }: OrchestratorModalProps) {
+  const workflowStatusFilter = 'RUNNING,STARTING,WAITING_FOR_INPUT,WAITING_FOR_APPROVAL,ERROR,IDLE';
   const modalRef = useRef<HTMLDivElement>(null);
   const [idleExpanded, setIdleExpanded] = useState(false);
   const {
-    isOpen,
     close,
     ingestSessions,
     ingestSnapshot,
@@ -31,6 +36,7 @@ export function OrchestratorModal({ className }: OrchestratorModalProps) {
     pruneApprovals,
     dismissItem,
     getActiveItems,
+    getWaitingItems,
     getIdledItems,
   } = useOrchestratorStore();
   const { setSessionIdle } = useSessionIdle();
@@ -58,6 +64,7 @@ export function OrchestratorModal({ className }: OrchestratorModalProps) {
   );
 
   const activeItems = getActiveItems();
+  const waitingItems = getWaitingItems();
   const idledItems = getIdledItems();
   const idledCount = idledItems.length;
 
@@ -65,12 +72,11 @@ export function OrchestratorModal({ className }: OrchestratorModalProps) {
   const { refetch: refetchSessions } = useQuery({
     queryKey: ['orchestrator', 'sessions'],
     queryFn: async () => {
-      const data = await getSessions({ include_archived: false, status: attentionStatusFilter });
+      const data = await getSessions({ include_archived: false, status: workflowStatusFilter });
       ingestSessions(data.sessions as any, { fullSync: true });
       return data;
     },
-    enabled: isOpen,
-    refetchInterval: isOpen ? 10000 : false, // Refetch every 10s when open
+    refetchInterval: 10000, // Refetch every 10s when open
   });
 
   // Fetch pending approvals when modal opens
@@ -84,16 +90,13 @@ export function OrchestratorModal({ className }: OrchestratorModalProps) {
       pruneApprovals(data.approvals.map((approval) => approval.id));
       return data;
     },
-    enabled: isOpen,
   });
 
-  const { summariesEnabled } = useOrchestratorSummaries(activeItems, isOpen);
+  const { summariesEnabled } = useOrchestratorSummaries(activeItems, true);
 
   // WebSocket subscriptions when modal is open
   const handleWebSocketMessage = useCallback(
     (message: ServerToUIMessage) => {
-      if (!isOpen) return;
-
       switch (message.type) {
         case 'sessions.changed': {
           const payload = message.payload as { sessions: Session[] };
@@ -140,24 +143,20 @@ export function OrchestratorModal({ className }: OrchestratorModalProps) {
         }
       }
     },
-    [isOpen, ingestSessions, ingestSnapshot, ingestApproval, removeApprovalItem]
+    [ingestSessions, ingestSnapshot, ingestApproval, removeApprovalItem]
   );
 
   useWebSocket(
-    isOpen
-      ? [
-          { type: 'sessions', filter: { status: attentionStatusFilter } },
-          { type: 'snapshots' },
-          { type: 'approvals', filter: { status: 'pending' } },
-        ]
-      : [],
+    [
+      { type: 'sessions', filter: { status: workflowStatusFilter } },
+      { type: 'snapshots' },
+      { type: 'approvals', filter: { status: 'pending' } },
+    ],
     handleWebSocketMessage
   );
 
   // Handle escape key and focus trap
   useEffect(() => {
-    if (!isOpen) return;
-
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
@@ -167,11 +166,11 @@ export function OrchestratorModal({ className }: OrchestratorModalProps) {
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, close]);
+  }, [close]);
 
   // Focus trap
   useEffect(() => {
-    if (!isOpen || !modalRef.current) return;
+    if (!modalRef.current) return;
 
     const focusableElements = modalRef.current.querySelectorAll<HTMLElement>(
       'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
@@ -197,14 +196,12 @@ export function OrchestratorModal({ className }: OrchestratorModalProps) {
     setTimeout(() => firstElement?.focus(), 0);
 
     return () => document.removeEventListener('keydown', handleTabKey);
-  }, [isOpen]);
+  }, []);
 
   const handleRefresh = useCallback(() => {
     refetchSessions();
     refetchApprovals();
   }, [refetchSessions, refetchApprovals]);
-
-  if (!isOpen) return null;
 
   return (
     <>
@@ -265,7 +262,7 @@ export function OrchestratorModal({ className }: OrchestratorModalProps) {
 
         {/* Content */}
         <div className="max-h-[60vh] overflow-y-auto p-3 space-y-2">
-          {activeItems.length === 0 && idledItems.length === 0 ? (
+          {activeItems.length === 0 && waitingItems.length === 0 && idledItems.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">
               <Bell className="h-12 w-12 mx-auto mb-3 opacity-30" />
               <p className="text-sm">No sessions need your attention</p>
@@ -275,7 +272,7 @@ export function OrchestratorModal({ className }: OrchestratorModalProps) {
             </div>
           ) : (
             <>
-              {activeItems.length === 0 && idledItems.length > 0 && (
+              {activeItems.length === 0 && waitingItems.length === 0 && idledItems.length > 0 && (
                 <div className="text-center py-4 text-muted-foreground">
                   <p className="text-sm">All items are idled</p>
                 </div>
@@ -291,6 +288,27 @@ export function OrchestratorModal({ className }: OrchestratorModalProps) {
                   summariesEnabled={summariesEnabled}
                 />
               ))}
+
+              {/* Waiting items */}
+              {waitingItems.length > 0 && (
+                <div className="border-t mt-3 pt-3">
+                  <p className="text-xs text-muted-foreground mb-2">
+                    Waiting ({waitingItems.length})
+                  </p>
+                  {waitingItems.map((item) => (
+                    <OrchestratorItem
+                      key={item.id}
+                      item={item}
+                      onDismiss={dismissItem}
+                      onIdle={handleIdle}
+                      onUnidle={handleUnidle}
+                      onResponseSent={handleRefresh}
+                      mode="waiting"
+                      showSummary={false}
+                    />
+                  ))}
+                </div>
+              )}
 
               {/* Idle section */}
               {idledItems.length > 0 && (

--- a/apps/dashboard/src/stores/orchestrator.ts
+++ b/apps/dashboard/src/stores/orchestrator.ts
@@ -318,6 +318,13 @@ function isActionableItem(item: OrchestratorItem): boolean {
     return isActionableApproval(item);
   }
 
+  // For non-approval items, the session status is authoritative.
+  // This prevents snapshot-based items from de-counting sessions that are
+  // already WAITING_FOR_INPUT/WAITING_FOR_APPROVAL.
+  if (ATTENTION_STATUSES.has(item.sessionStatus)) {
+    return true;
+  }
+
   if (!item.action) return false;
   if (item.action.type === 'text_input') return false;
   if (item.action.type === 'needs_attention') return false;
@@ -409,6 +416,7 @@ export const useOrchestratorStore = create<OrchestratorState>()(
           const now = Date.now();
 
           for (const session of sessions) {
+            const isArchived = Boolean(session.archived_at);
             const previousStatus = state.sessionsById[session.id]?.status;
             const wasAttention = previousStatus ? ATTENTION_STATUSES.has(previousStatus) : false;
             const isAttention = ATTENTION_STATUSES.has(session.status);
@@ -423,6 +431,17 @@ export const useOrchestratorStore = create<OrchestratorState>()(
               idledSessionsById[session.id] = parsedIdledAt as number;
             } else {
               delete idledSessionsById[session.id];
+            }
+
+            if (isArchived) {
+              items = items.filter(
+                (item) =>
+                  item.sessionId !== session.id ||
+                  item.source === 'approval'
+              );
+              delete lastHashBySession[session.id];
+              delete lastDetectedAt[session.id];
+              continue;
             }
 
             const snapshotContext = analyzeSnapshots && session.latest_snapshot?.capture_text
@@ -655,9 +674,51 @@ export const useOrchestratorStore = create<OrchestratorState>()(
             ];
           } else {
             // No action detected - remove existing snapshot items for this session only
-            newState.items = state.items.filter(
+            let items = state.items.filter(
               (item) => !(item.sessionId === sessionId && item.source === 'snapshot')
             );
+            const session = state.sessionsById[sessionId];
+            const sessionStatus = session?.status;
+            const needsAttention =
+              typeof sessionStatus === 'string' && ATTENTION_STATUSES.has(sessionStatus);
+            if (needsAttention) {
+              const hasActiveApproval = items.some(
+                (item) =>
+                  item.sessionId === sessionId &&
+                  item.source === 'approval' &&
+                  !item.dismissedAt
+              );
+              const hasActiveStatus = items.some(
+                (item) =>
+                  item.sessionId === sessionId &&
+                  item.source === 'status' &&
+                  !item.dismissedAt
+              );
+              if (!hasActiveApproval && !hasActiveStatus) {
+                const now = Date.now();
+                items = items.filter(
+                  (item) => !(item.sessionId === sessionId && item.source === 'status')
+                );
+                items.push({
+                  id: `status-${sessionId}-${now}`,
+                  sessionId,
+                  sessionTitle: session?.title ?? null,
+                  sessionCwd: session?.cwd ?? null,
+                  sessionProvider: session?.provider ?? null,
+                  sessionStatus: sessionStatus as string,
+                  source: 'status',
+                  action: {
+                    type: 'needs_attention',
+                    question: `Session is ${String(sessionStatus).toLowerCase().replace(/_/g, ' ')}`,
+                    context: '',
+                    confidence: 0.5,
+                  },
+                  createdAt: now,
+                  idledAt: isIdledSession ? storedIdledAt : undefined,
+                });
+              }
+            }
+            newState.items = items;
           }
 
           const snapshotContext = buildSnapshotContext(captureText);

--- a/tasks/2026-02-14-mobile-ux-orchestrator-refactor.md
+++ b/tasks/2026-02-14-mobile-ux-orchestrator-refactor.md
@@ -1,0 +1,27 @@
+# Agent Command — Mobile UX & Orchestrator Refactor
+
+**Date:** 2026-02-14
+**Status:** Implemented
+
+---
+
+## Changes Implemented
+
+### Change 1: Fix Orchestrator Item Visibility
+
+**Files modified:**
+- `apps/dashboard/src/stores/orchestrator.ts` — Added status-source check to `isActionableItem()` so sessions in `WAITING_FOR_INPUT`/`WAITING_FOR_APPROVAL`/`ERROR` are treated as actionable
+- `apps/dashboard/src/components/orchestrator/OrchestratorButton.tsx` — Added snapshot WS subscription + `snapshots.updated` handler for background monitoring
+- `apps/dashboard/src/app/(dashboard)/orchestrator/OrchestratorPageClient.tsx` — Added waiting items section after active items
+- `apps/dashboard/src/components/orchestrator/OrchestratorModal.tsx` — Added waiting items section after active items
+
+### Change 2: Terminal Maximize/Fullscreen Toggle
+
+**Files modified:**
+- `apps/dashboard/src/app/(dashboard)/sessions/[id]/page.tsx` — Added `maximized` state, Maximize2/Minimize2 toggle button, fixed fullscreen overlay at z-[60], Escape key handler
+
+### Change 3: Fix Mobile Terminal Touch Scrolling
+
+**Files modified:**
+- `apps/dashboard/src/components/TerminalView.tsx` — Replaced `touch-pan-y` with conditional `touch-none` on mobile, always `preventDefault` on vertical touchmove, added momentum scrolling with deceleration
+- `apps/dashboard/src/app/globals.css` — Removed `touch-action: pan-y` from `.xterm .xterm-viewport`, set `touch-action: none` in mobile media query

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -7,3 +7,7 @@
 - Date: 2026-02-07
   Correction: User flagged that edits should use the `apply_patch` tool (not running an apply_patch script via `exec_command`).
   Rule: When modifying files, use the `functions.apply_patch` tool for patches instead of invoking `apply_patch` through shell commands.
+
+- Date: 2026-02-14
+  Correction: User asked to store this kind of refactor/implementation note under `tasks/` instead of the repo root.
+  Rule: Put internal implementation notes in `tasks/` using an ISO date prefix in the filename.


### PR DESCRIPTION
Summary:\n- Mount orchestrator button + modal globally (badge + Shift+O actually works)\n- Fix stale badge/items by broadening session WS subscription\n- Treat attention statuses as authoritative for non-approval items; restore status items when snapshot action clears\n- Improve mobile terminal touch scrolling (momentum cleanup + multi-touch guard)\n- Improve terminal fullscreen Escape behavior\n- Move implementation note into tasks/ and record lesson\n\nVerification:\n- pnpm -w typecheck\n- pnpm -w lint\n- pnpm -w test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added orchestrator controls (button and modal) to the dashboard header.
  * Introduced a "Waiting" section in the orchestrator to display items requiring attention.
  * Added fullscreen toggle button for the terminal view with keyboard shortcut support (Esc to exit).
  * Implemented momentum-based touch scrolling for improved mobile terminal interaction.

* **Bug Fixes**
  * Fixed mobile touch gesture handling for terminal scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->