### PR TITLE
fix: acknowledge stale session usage

### DIFF
--- a/services/control-plane/src/ws/agent.ts
+++ b/services/control-plane/src/ws/agent.ts
@@ -915,6 +915,9 @@ async function handleSessionUsageReport(
   payload: unknown
 ): Promise<void> {
   const parsed = SessionUsageSummarySchema.parse(payload);
+  const session = await db.getSessionById(parsed.session_id);
+  if (!session) return;
+
   await db.upsertSessionUsageLatest(parsed);
 
   pubsub.publishToUI({


### PR DESCRIPTION
## Production failure
A durable session.usage message for a pruned session raised PostgreSQL 23503. The WebSocket handler closed without ACK, so the same sequence was redelivered forever and blocked ACP command results.

## Fix
Confirm the parent session still exists before persistence or publication. A stale report returns normally and is ACKed; real database errors continue to propagate.

## Verification
- Luna Max implementation
- Opus 5 independent review on homelinux: PASS_WITH_FINDINGS, safe to deploy
- control-plane TypeScript build passed
- git diff --check passed
- zero tests added, changed, or run

The head commit uses [skip ci] to honor the explicit no-test instruction for this narrow production repair.