### PR TITLE
fix(acp): accept stale quota readings

### DIFF
--- a/agents/agentd/cmd/agentd/main.go
+++ b/agents/agentd/cmd/agentd/main.go
@@ -2098,7 +2098,7 @@ func parseACPQuota(value any) (map[string]any, error) {
 		if !providerOK || !poolOK || !confidenceOK {
 			return nil, fmt.Errorf("quota pool is missing operator-safe fields")
 		}
-		if confidence != "measured" && confidence != "unmeasurable" {
+		if confidence != "measured" && confidence != "stale" && confidence != "unmeasurable" {
 			return nil, fmt.Errorf("quota confidence is invalid")
 		}
 
@@ -2106,7 +2106,7 @@ func parseACPQuota(value any) (map[string]any, error) {
 		if !usedOK {
 			return nil, fmt.Errorf("quota used_percent is invalid")
 		}
-		status := "measured"
+		status := confidence
 		var used any
 		switch typed := usedValue.(type) {
 		case float64:

--- a/apps/dashboard/src/app/(dashboard)/hosts/ACPStatusPanel.tsx
+++ b/apps/dashboard/src/app/(dashboard)/hosts/ACPStatusPanel.tsx
@@ -64,6 +64,8 @@ function QuotaItem({ item }: { item: ACPQuotaItem }) {
   const label = shared
     ? item.status === 'exhausted'
       ? 'Exhausted · Shared / nonblocking'
+      : item.status === 'stale'
+        ? 'Stale · Shared / nonblocking'
       : 'Shared / nonblocking'
     : item.status === 'exhausted'
       ? 'Exhausted'

--- a/apps/dashboard/src/app/(dashboard)/hosts/ACPStatusPanel.tsx
+++ b/apps/dashboard/src/app/(dashboard)/hosts/ACPStatusPanel.tsx
@@ -67,9 +67,11 @@ function QuotaItem({ item }: { item: ACPQuotaItem }) {
       : 'Shared / nonblocking'
     : item.status === 'exhausted'
       ? 'Exhausted'
-      : item.status === 'unmeasurable'
-        ? 'Unmeasurable'
-        : 'Measured';
+      : item.status === 'stale'
+        ? 'Stale'
+        : item.status === 'unmeasurable'
+          ? 'Unmeasurable'
+          : 'Measured';
   return (
     <li className="space-y-2 rounded-md border p-3">
       <div className="flex items-start justify-between gap-2">

--- a/packages/ac-schema/src/command.ts
+++ b/packages/ac-schema/src/command.ts
@@ -496,8 +496,8 @@ const ACPQuotaItemSchema = z
     pool_id: z.string(),
     used_percent: z.number().nullable(),
     resets_at: z.string().nullable(),
-    confidence: z.enum(['measured', 'unmeasurable']),
-    status: z.enum(['measured', 'exhausted', 'unmeasurable']),
+    confidence: z.enum(['measured', 'stale', 'unmeasurable']),
+    status: z.enum(['measured', 'stale', 'exhausted', 'unmeasurable']),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- accept the quota contract's `stale` confidence value in agentd and the shared schema
- preserve stale item status unless the pool is exhausted
- render stale quota rows truthfully in the ACP panel

## Live failure fixed
A single contract-valid stale pool made Agent Commander mark the entire quota section unavailable.

## Verification
- agentd build passed
- `@agent-command/schema` typecheck passed
- homelinux Opus 5: PASS_WITH_FINDINGS; safe to deploy with control-plane/schema before agentd
- no tests added, changed, or manually run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying stale quota information in ACP status views.
  * Quota entries with stale confidence now show a clear “Stale” label.

* **Bug Fixes**
  * Preserved accurate quota statuses instead of defaulting all entries to “Measured.”
  * Continued correctly identifying exhausted and unmeasurable quotas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->