### PR TITLE
fix(acp): restore measured subscription readiness

### DIFF
--- a/agents/agentd/internal/acp/acp.go
+++ b/agents/agentd/internal/acp/acp.go
@@ -563,8 +563,10 @@ func parseQuota(src source) (map[string]any, error) {
 		} else if *used >= quotaExhaustedUsed {
 			status = "exhausted"
 		}
+		usedPercent := any(nil)
 		remaining := any(nil)
 		if used != nil {
+			usedPercent = *used
 			remaining = maxFloat(0, 100-*used)
 		}
 		effect := "routable"
@@ -580,7 +582,7 @@ func parseQuota(src source) (map[string]any, error) {
 			effect = "held: reserve floor"
 		}
 		item := map[string]any{
-			"provider": provider, "pool_id": poolID, "used_percent": used,
+			"provider": provider, "pool_id": poolID, "used_percent": usedPercent,
 			"remaining_percent": remaining, "resets_at": resets, "confidence": confidence,
 			"status": status, "shared": shared, "routing_enabled": routingEnabled,
 			"effect": effect,


### PR DESCRIPTION
## Fix

Normalizes the parsed quota pointer to a JSON-number value before the in-process routing policy evaluates it. Fresh measured non-shared pools now satisfy the configured reserve floor; exhausted team/shared capacity remains nonblocking.

## Scope

One representation fix discovered by the real post-deploy quota refresh. No synthetic budget logic, retry, fallback, or new test.