### PR TITLE
fix(acp): keep unset identities fail-closed

### DIFF
--- a/services/control-plane/src/config.ts
+++ b/services/control-plane/src/config.ts
@@ -6,6 +6,11 @@ const OptionalPositiveInteger = z.preprocess(
   z.coerce.number().int().positive().optional()
 );
 
+const OptionalUuid = z.preprocess(
+  (value) => value === '' || value === undefined ? undefined : value,
+  z.string().uuid().optional()
+);
+
 const ConfigSchema = z.object({
   DATABASE_URL: z.string().min(1),
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
@@ -21,8 +26,8 @@ const ConfigSchema = z.object({
   RATE_LIMIT_WINDOW_MS: z.coerce.number().int().positive().default(60_000),
   WS_ALLOWED_ORIGINS: z.string().optional(),
   WS_TICKET_TTL_SECONDS: z.coerce.number().int().positive().max(300).default(30),
-  ACP_SOURCE_HOST_ID: z.string().uuid().optional(),
-  ACP_APPROVER_USER_ID: z.string().uuid().optional(),
+  ACP_SOURCE_HOST_ID: OptionalUuid,
+  ACP_APPROVER_USER_ID: OptionalUuid,
   VAPID_PUBLIC_KEY: z.string().min(1).optional(),
   VAPID_PRIVATE_KEY: z.string().min(1).optional(),
   VAPID_SUBJECT: z.string().regex(/^(mailto:|https:)/).optional(),


### PR DESCRIPTION
## Summary
- normalize blank ACP identity env values to unset before UUID validation
- keep invalid non-empty UUIDs rejected
- prevent the control plane from crash-looping when Compose supplies blank optional values

## Verification
- `pnpm --filter @agent-command/control-plane build`
- `git diff --check`
- homelinux Claude Opus 5 targeted rereview: PASS

## Test delta
- tests added: none
- tests changed: none
- local test suites run: none
- protected repository checks will run automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration fields for source hosts and approver users now correctly accept empty or unspecified values while still validating provided UUIDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->